### PR TITLE
Fix RGL sign in for Dr490n Launcher/MTL

### DIFF
--- a/Auth/MTLInterface.cs
+++ b/Auth/MTLInterface.cs
@@ -106,7 +106,7 @@ namespace Project_127.Auth
             //var posixtime = BitConverter.ToInt32(blob.Skip(0x3170).Take(4).ToArray(), 0); //Broklen
             var posixtime = (int)ROSCommunicationBackend.GetPosixTime() + 24 * 3600;
             var RockstarID = BitConverter.ToUInt64(blob.Skip(0xEE8).Take(8).ToArray(), 0);
-            var sessKey = blob.Skip(0x10D8).Take(16).ToArray();
+            var sessKey = blob.Skip(0x1108).Take(16).ToArray();
             var ticket = Encoding.UTF8.GetString(blob.Skip(0xAF0).TakeWhile(a => a != 0).ToArray());
             var sessTicket = Encoding.UTF8.GetString(blob.Skip(0xCF0).TakeWhile(a => a != 0).ToArray());
             var rockstarNick = Encoding.UTF8.GetString(blob.Skip(0xE9F).TakeWhile(a => a != 0).ToArray());


### PR DESCRIPTION
A Social Club update broke the sign in by moving the session key further down. This commit fixes the offset of it. 

Big thanks to nta for his related fix on FiveM - https://github.com/citizenfx/fivem/commit/708ceea9d1f7d41f394962d737651ee5c0321bcf