### PR TITLE
Fix MTL/ROS offsets.

### DIFF
--- a/Auth/MTLInterface.cs
+++ b/Auth/MTLInterface.cs
@@ -105,11 +105,11 @@ namespace Project_127.Auth
             var blob = new ArraySegment<byte>(scmem, (int)blob_offset, 16384);
             //var posixtime = BitConverter.ToInt32(blob.Skip(0x3170).Take(4).ToArray(), 0); //Broklen
             var posixtime = (int)ROSCommunicationBackend.GetPosixTime() + 24 * 3600;
-            var RockstarID = BitConverter.ToUInt64(blob.Skip(0xEE8).Take(8).ToArray(), 0);
-            var sessKey = blob.Skip(0x1108).Take(16).ToArray();
+            var RockstarID = BitConverter.ToUInt64(blob.Skip(0xEF0).Take(8).ToArray(), 0);
+            var sessKey = blob.Skip(0x1110).Take(16).ToArray();
             var ticket = Encoding.UTF8.GetString(blob.Skip(0xAF0).TakeWhile(a => a != 0).ToArray());
             var sessTicket = Encoding.UTF8.GetString(blob.Skip(0xCF0).TakeWhile(a => a != 0).ToArray());
-            var rockstarNick = Encoding.UTF8.GetString(blob.Skip(0xE9F).TakeWhile(a => a != 0).ToArray());
+            var rockstarNick = Encoding.UTF8.GetString(blob.Skip(0xEA7).TakeWhile(a => a != 0).ToArray());
             var countryCode = Encoding.UTF8.GetString(blob.Skip(0xE0C).TakeWhile(a => a != 0).ToArray());
 
             if (/*posixtime == 0 ||*/ rockstarNick == "")


### PR DESCRIPTION
On 13/04/2024 (or 14/04/2024) an RGL update was released that once again messed with the offsets that P127 uses to create a session. This PR fixes those offsets - this time only RockstarID, sessionKey and rockstarNick were affected.

Thanks to nihonium-cfx for the new offsets, taken from https://github.com/citizenfx/fivem/commit/2841a5cc9ef1a95c5f00db91b6e5c074141e475e