### PR TITLE
DragonEmu AsiLoader Hook Fix

### DIFF
--- a/Installer/DownloadManager.xml
+++ b/Installer/DownloadManager.xml
@@ -165,7 +165,7 @@
         <mirror>http://gtav.anushk.net/downloadManager/subassemblies/Downgraded_Socialclub.zip</mirror>
     </subassembly>
 
-    <subassembly name="STANDARD_BASE" root="DowngradeFiles\" version="1.20.0.0">
+    <subassembly name="STANDARD_BASE" root="DowngradeFiles\" version="1.21.0.0">
         <file name="PlayGTAV.exe" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
         <file name="launc.dll" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
         <file name="orig_socialclub.dll" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
@@ -192,7 +192,7 @@
         </requires>
     </subassembly>
 
-	<subassembly name="124_DR490N" root="DowngradeFiles124\" version="1.20.0.0">
+	<subassembly name="124_DR490N" root="DowngradeFiles124\" version="1.21.0.0">
 		<file name="PlayGTAV.exe" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
 		<file name="launc.dll" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
 		<file name="orig_socialclub.dll" linked="true" subassembly="EMU_BASE_SUBASSEMBLY"/>
@@ -219,7 +219,7 @@
 	</subassembly>
     
 
-    <subassembly name="EMU_BASE_SUBASSEMBLY" type="common" version ="1.20.0.0">
+    <subassembly name="EMU_BASE_SUBASSEMBLY" type="common" version ="1.21.0.0">
         <file name="PlayGTAV.exe">
             <hash>5F4F8AE07CC5EED5204583B99E9889C0</hash>
             <mirror>http://gtav.anushk.net/downloadManager/subassemblies/emuv16_complete/PlayGTAV.exe</mirror>
@@ -249,8 +249,8 @@
             <mirror>http://gtav.anushk.net/downloadManager/subassemblies/emuv16_complete/bink2w64.dll</mirror>
         </file>-->
 		<file name="bink2w64.dll">
-            <hash>3c73fbf789bf1ed34e4246940eb4d8f4</hash>
-            <mirror>http://gtav.anushk.net/downloadManager/subassemblies/emu_stutterfix_v5_allfixes/bink2w64.dll</mirror>
+            <hash>e52021bb5948b7e18668d54e9d2c743e</hash>
+            <mirror>http://gtav.anushk.net/downloadManager/subassemblies/emu_stutterfix_v6_allfixes_asiloaderfix/bink2w64.dll</mirror>
         </file>
     </subassembly>
 


### PR DESCRIPTION
Asi Loader in ScriptHookV used to override our hook on GetSystemTimeAsFileTime. New bink2w64.dll fixes that.