### PR TITLE
Add support for XboxPC retailer

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -245,7 +245,7 @@ namespace Project_127
 
         public static string ExplorerExeFilePath { get { return WindowsDirectory.TrimEnd('\\') + @"\explorer.exe"; } } 
 
-        public static string NotepadExeFilePath { get { return WindowsDirectory.TrimEnd('\\') + @"\notepad.exe"; } }
+        public static string NotepadExeFilePath { get { return WindowsDirectory.TrimEnd('\\') + @"\System32\notepad.exe"; } }
 
         /// <summary>
         /// Returns all Command Line Args as StringArray
@@ -2168,3 +2168,4 @@ namespace Project_127
 
     } // End of Class
 } // End of Namespace
+

--- a/Globals.cs
+++ b/Globals.cs
@@ -813,6 +813,29 @@ namespace Project_127
                     Settings.AntiControlledFolderFix();
                 }
 
+				if (Settings.LastLaunchedVersion < new Version("1.5.4.0"))
+				{
+    				HelperClasses.Logger.Log("Last launched version is below 1.5.4.0");
+    				if (Settings.Retailer != Settings.Retailers.XboxPC)
+    				{
+        				try
+        				{
+            				RegistryKey BaseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64).OpenSubKey(@"SOFTWARE\WOW6432Node\Rockstar Games\Grand Theft Auto V");
+            				string XboxInstallFolder = HelperClasses.RegeditHandler.GetValue(BaseKey, "InstallFolderXboxPc");
+            				if (!string.IsNullOrEmpty(XboxInstallFolder))
+            				{
+                				bool XboxChoice = PopupWrapper.PopupYesNo("Project 1.27 now supports XboxPC (Game Pass) retailer.\nIs your GTA V retailer XboxPC?");
+                				if (XboxChoice == true)
+                				{
+                    				Settings.Retailer = Settings.Retailers.XboxPC;
+                				}
+            				}
+        				}
+
+        				catch { }
+    				}
+				}
+
                 Settings.LastLaunchedVersion = Globals.ProjectVersion;
 
                 HelperClasses.Logger.Log("Deleting CEF_CacheFiles because you are on a P127 version you have not launched on your system yet.");
@@ -2168,4 +2191,5 @@ namespace Project_127
 
     } // End of Class
 } // End of Namespace
+
 

--- a/HelperClasses/FileHandler.cs
+++ b/HelperClasses/FileHandler.cs
@@ -159,7 +159,7 @@ string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
                 {
                     if (Settings.Retailer == Settings.Retailers.XboxPC)
                     {
-                        if (filePath == LauncherLogic.GTAVFilePath.TrimEnd('\\') + @"\gta5.exe" || filePath == LauncherLogic.UpgradeFilePath.TrimEnd('\\') + @"\gta5.exe")
+                        if (String.Equals(filePath, LauncherLogic.GTAVFilePath.TrimEnd('\\') + @"\gta5.exe", StringComparison.OrdinalIgnoreCase) || String.Equals(filePath, LauncherLogic.UpgradeFilePath.TrimEnd('\\') + @"\gta5.exe", StringComparison.OrdinalIgnoreCase))
                         {
                             rtrn = new Version("99.99.99.99");
                         }

--- a/HelperClasses/FileHandler.cs
+++ b/HelperClasses/FileHandler.cs
@@ -155,7 +155,13 @@ string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
                     FileVersionInfo FVI = FileVersionInfo.GetVersionInfo(filePath);
                     rtrn = new Version(FVI.FileVersion);
                 }
-                catch { }
+                catch
+                {
+                    if (Settings.Retailer == Settings.Retailers.XboxPC && filePath == LauncherLogic.GTAVFilePath.TrimEnd('\\') + @"\gta5.exe")
+                    {
+                        rtrn = new Version("99.99.99.99");
+                    }
+                }
             }
 
             return rtrn;

--- a/HelperClasses/FileHandler.cs
+++ b/HelperClasses/FileHandler.cs
@@ -157,9 +157,12 @@ string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
                 }
                 catch
                 {
-                    if (Settings.Retailer == Settings.Retailers.XboxPC && filePath == LauncherLogic.GTAVFilePath.TrimEnd('\\') + @"\gta5.exe")
+                    if (Settings.Retailer == Settings.Retailers.XboxPC)
                     {
-                        rtrn = new Version("99.99.99.99");
+                        if (filePath == LauncherLogic.GTAVFilePath.TrimEnd('\\') + @"\gta5.exe" || filePath == LauncherLogic.UpgradeFilePath.TrimEnd('\\') + @"\gta5.exe")
+                        {
+                            rtrn = new Version("99.99.99.99");
+                        }
                     }
                 }
             }

--- a/LauncherLogic.cs
+++ b/LauncherLogic.cs
@@ -393,7 +393,7 @@ namespace Project_127
             }
             set
             {
-                if (Settings.Retailer == Settings.Retailers.Epic)
+                if (Settings.Retailer == Settings.Retailers.Epic || Settings.Retailer == Settings.Retailers.XboxPC)
                 {
                     if (value == LaunchWays.SocialClubLaunch)
                     {
@@ -1098,6 +1098,12 @@ namespace Project_127
                     // This does not work with custom wrapper StartProcess in ProcessHandler...i guess this is fine
                     Process.Start(@"com.epicgames.launcher://apps/9d2d0eb64d5c44529cece33fe2a46482?action=launch&silent=true");
                 }
+                // If XboxPC
+                else if (Settings.Retailer == Settings.Retailers.XboxPC)
+                {
+                    HelperClasses.Logger.Log("Trying to start Game normally through XboxPC.", 1);
+                    Process.Start(@"msgamelaunch://shortcutLaunch/?ProductId=9N9RSV4F7ZR0&Exe=GTAO");
+                }
                 // If Rockstar
                 else
                 {
@@ -1295,7 +1301,7 @@ namespace Project_127
                         {
                             Upgrade(false, true);
 
-                            if (LauncherLogic.LaunchWay == LauncherLogic.LaunchWays.DragonEmu || Settings.Retailer == Settings.Retailers.Epic)
+                            if (LauncherLogic.LaunchWay == LauncherLogic.LaunchWays.DragonEmu || Settings.Retailer == Settings.Retailers.Epic || Settings.Retailer == Settings.Retailers.XboxPC)
                             {
                                 if (Settings.DragonEmuGameVersion == "124")
                                 {
@@ -2050,6 +2056,7 @@ namespace Project_127
                 HelperClasses.Logger.Log("WriteReturningPlayerBonusToFile: " + filePath);
             }
         }
+
 
     } // End of Class
 } // End of NameSpace

--- a/LauncherLogic.cs
+++ b/LauncherLogic.cs
@@ -1372,6 +1372,12 @@ namespace Project_127
                 NewPath = Directory.GetParent(OrigPath).ToString().TrimEnd('\\') + @"\UpgradeFiles_Backup_" + NewPath.TrimEnd('\\');
             }
 
+            if (Settings.Retailer == Settings.Retailers.XboxPC)
+            {
+                PopupWrapper.PopupOk("Backup not available for XboxPC retailer.");
+                return;
+            }
+
             if (!(HelperClasses.FileHandling.GetFilesFromFolderAndSubFolder(UpgradeFilePath).Length >= 2 && HelperClasses.BuildVersionTable.IsUpgradedGTA(UpgradeFilePath)))
             {
                 PopupWrapper.PopupOk("No Upgrade Files available to back up.");
@@ -2060,4 +2066,5 @@ namespace Project_127
 
     } // End of Class
 } // End of NameSpace
+
 

--- a/MySettings/InitImportantSettings.xaml.cs
+++ b/MySettings/InitImportantSettings.xaml.cs
@@ -140,6 +140,8 @@ namespace Project_127.MySettings
                     HelperClasses.Logger.Log("Init important settings, in addGuesses, in RegistryBaseKey foreach, post epic");
                     string PossibleRockstar = HelperClasses.RegeditHandler.GetValue(myRKTemp, "InstallFolder");
                     HelperClasses.Logger.Log("Init important settings, in addGuesses, in RegistryBaseKey foreach, post rockstar");
+                    string PossibleXboxPC = HelperClasses.RegeditHandler.GetValue(myRKTemp, "InstallFolderXboxPc");
+                    HelperClasses.Logger.Log("Init important settings, in addGuesses, in RegistryBaseKey foreach, post XboxPC");
 
                     if (!string.IsNullOrEmpty(PossibleSteam))
                     {
@@ -152,6 +154,11 @@ namespace Project_127.MySettings
                     if (!string.IsNullOrEmpty(PossibleRockstar))
                     {
                         GTAVPathGuessesDuplicates.Add(new GTAVPathGuess(PossibleRockstar, Retailers.Rockstar));
+                    }
+
+                    if (!string.IsNullOrEmpty(PossibleXboxPC))
+                    {
+                        GTAVPathGuessesDuplicates.Add(new GTAVPathGuess(PossibleXboxPC, Retailers.XboxPC));
                     }
                 }
                 catch { }

--- a/MySettings/Settings.xaml
+++ b/MySettings/Settings.xaml
@@ -251,7 +251,7 @@
                                     <Label Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" x:Name="lbl_LaunchWays" Content="Launch - Method" Style="{StaticResource lbl_Set_Info}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                     <Button Grid.Row="1" Grid.Column="0" Margin="20,0,20,15" x:Name="btn_LaunchWays_SCL" ToolTip="Launch through original Socialclub. This needs the corresponding Launch-Through-SocialClub Component" Style="{StaticResource btn_LaunchWays_SCL}" Content="Launch through Social Club" Click="btn_LaunchWays_SCL_Click"/>
                                     <Button Grid.Row="1" Grid.Column="1" Margin="20,0,20,15" x:Name="btn_LaunchWays_DragonEmu" ToolTip="Launch through @dr490ns Launcher. Only needs 'Required Files'" Style="{StaticResource btn_LaunchWays_DragonEmu}" Content="Launch through Dr490n Launcher" Click="btn_LaunchWays_DragonEmu_Click"/>
-                                    <Rectangle x:Name="Rect_HideOptions_SCL_Launch" Grid.Row="1" Grid.Column="0" Margin="20,0,20,15" Fill="{x:Static local:MyColors.MyColorOffWhite85}" ToolTip="Not available on Epic."/>
+                                    <Rectangle x:Name="Rect_HideOptions_SCL_Launch" Grid.Row="1" Grid.Column="0" Margin="20,0,20,15" Fill="{x:Static local:MyColors.MyColorOffWhite85}" ToolTip="Not available on Epic or XboxPC."/>
                                 </Grid>
                             </Border>
 

--- a/MySettings/Settings.xaml.cs
+++ b/MySettings/Settings.xaml.cs
@@ -1246,7 +1246,7 @@ namespace Project_127.MySettings
                 Rect_HideOptions_AutoCoreFix.Visibility = Visibility.Visible;
             }
 
-            if (Retailer == Retailers.Epic)
+            if (Retailer == Retailers.Epic || Retailer == Retailers.XboxPC)
             {
                 Rect_HideOptions_SCL_Launch.Visibility = Visibility.Visible;
             }
@@ -2392,3 +2392,4 @@ namespace Project_127.MySettings
 
     } // End of Class
 } // End of Namespace 
+

--- a/MySettings/SettingsPartial.cs
+++ b/MySettings/SettingsPartial.cs
@@ -776,7 +776,8 @@ namespace Project_127.MySettings
             // THESE NEED TO BE IN THAT SPELLING AND UPPERCASING
             Steam,
             Rockstar,
-            Epic
+            Epic,
+			XboxPC
         }
 
         /// <summary>
@@ -2086,6 +2087,7 @@ namespace Project_127.MySettings
             }
             return rtrn;
         }
+
 
 
     } // End of partial Class

--- a/Overlay/GTAOverlay.cs
+++ b/Overlay/GTAOverlay.cs
@@ -554,7 +554,7 @@ namespace Project_127.Overlay
 		/// <param name="text">Text to display</param>
 		public void setText(string text)
 		{
-			HelperClasses.Logger.Log("Overlay text updated");
+			//HelperClasses.Logger.Log("Overlay text updated");
 			this.text = text;
 		}
 
@@ -1393,3 +1393,4 @@ namespace Project_127.Overlay
 	}
 
 }
+

--- a/Popups/PopupProgress.xaml.cs
+++ b/Popups/PopupProgress.xaml.cs
@@ -381,89 +381,125 @@ namespace Project_127.Popups
                     CorrespondingFilePathInUpgradeFiles[i] = LauncherLogic.UpgradeFilePath + FilesInDowngradeFiles[i].Substring(LauncherLogic.DowngradeFilePath.Length);
 
                     string tmpFileWePlace = FilesInDowngradeFiles[i].Substring(LauncherLogic.DowngradeFilePath.Length).TrimStart('\\');
-
-
-                    if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic)
+                
+                    if (Settings.Retailer == Settings.Retailers.XboxPC)
                     {
-                        // Move to $UpgradeFiles
-                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting '" + CorrespondingFilePathInGTALocation + "' from $GTAInstallationDirectory, since this is a simple Downgrade after using a Backup", 1));
-                    }
-                    // Normal Downgrade Logic
-                    else
-                    {
-                        // If the File exists in GTA V Installation Path
                         if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInGTALocation[i]))
                         {
-                            // If the File we are replacing is the same as in DowngradeFiles
-                            if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
+                            if (!HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
                             {
-                                // Delete from GTA V Installation Path 
-                                MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Downgrade_Files. Will delelte from GTA V Installation", 1));
-                            }
-
-                            // If the File we are replacing is the same as in UpgradeFiles
-                            else if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
-                            {
-                                // Delete from GTA V Installation Path
-                                MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Upgrade_Files. Will delelte from GTA V Installation", 1));
-                            }
-
-                            // If the file we are replacing matches no file from UpgradeFiles or DowngradeFiles
-                            else
-                            {
-                                // if gta5 is upgraded
-                                if (BuildVersionTable.GetGameVersionOfBuild(Globals.GTABuild) > new Version(1, 30))
+                                if (!HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
                                 {
-                                    // offer backup
-                                    if (!UpdatePopupThrownAlready)
-                                    {
-                                        Application.Current.Dispatcher.Invoke((Action)delegate
-                                        {
-                                            bool yesno = PopupWrapper.PopupYesNo("Detected new Files inside your GTA Installation.\nP127 will use these as the files you revert to when Upgrading.\nDo you want me to back up your previous Upgrade - Files?");
-                                            if (yesno == true)
-                                            {
-                                                HelperClasses.Logger.Log("User does want it. Initiating CreateBackup()");
-
-                                                HelperClasses.ProcessHandler.KillRockstarProcesses();
-
-                                                LauncherLogic.CreateBackup();
-                                            }
-                                            else
-                                            {
-                                                HelperClasses.Logger.Log("User doesnt want it. Alright then");
-                                            }
-                                        });
-                                        UpdatePopupThrownAlready = true;
-                                    }
-
-
-                                    // If it exists in UpgradeFiles (but is an outdated Upgrade...)
-                                    if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
-                                    {
-                                        // Delte from $UpgradeFiles
-                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
-                                    }
-
-                                    // Move to $UpgradeFiles
-                                    Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
                                     MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
                                 }
+
+                                else if (!HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
+                                {
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
+                                }
+
+                            }
+                        }
+
+                        else
+                        {
+                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
+                        }
+
+                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
+
+                        HelperClasses.ProcessHandler.KillRockstarProcesses();
+
+                        RtrnMyFileOperations = MyFileOperationsTmp;
+                    }
+
+                    else
+                    {
+                    
+                        if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic)
+                        {
+                            // Move to $UpgradeFiles
+                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting '" + CorrespondingFilePathInGTALocation + "' from $GTAInstallationDirectory, since this is a simple Downgrade after using a Backup", 1));
+                        }
+                        // Normal Downgrade Logic
+                        else
+                        {
+                            // If the File exists in GTA V Installation Path
+                            if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInGTALocation[i]))
+                            {
+                                // If the File we are replacing is the same as in DowngradeFiles
+                                if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
+                                {
+                                    // Delete from GTA V Installation Path 
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Downgrade_Files. Will delelte from GTA V Installation", 1));
+                                }
+
+                                // If the File we are replacing is the same as in UpgradeFiles
+                                else if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
+                                {
+                                    // Delete from GTA V Installation Path
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Upgrade_Files. Will delelte from GTA V Installation", 1));
+                                }
+
+                                // If the file we are replacing matches no file from UpgradeFiles or DowngradeFiles
                                 else
                                 {
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path, since file matchings not $UpgradeFiles, not $DowngradeFiles and GTA from $GTA_DIR is NOT upgraded, so we dont want to move files to $UpgradeFiles", 1));
+                                    // if gta5 is upgraded
+                                    if (BuildVersionTable.GetGameVersionOfBuild(Globals.GTABuild) > new Version(1, 30))
+                                    {
+                                        // offer backup
+                                        if (!UpdatePopupThrownAlready)
+                                        {
+                                            Application.Current.Dispatcher.Invoke((Action)delegate
+                                            {
+                                                bool yesno = PopupWrapper.PopupYesNo("Detected new Files inside your GTA Installation.\nP127 will use these as the files you revert to when Upgrading.\nDo you want me to back up your previous Upgrade - Files?");
+                                                if (yesno == true)
+                                                {
+                                                    HelperClasses.Logger.Log("User does want it. Initiating CreateBackup()");
+
+                                                    HelperClasses.ProcessHandler.KillRockstarProcesses();
+
+                                                    LauncherLogic.CreateBackup();
+                                                }
+                                                else
+                                                {
+                                                    HelperClasses.Logger.Log("User doesnt want it. Alright then");
+                                                }
+                                            });
+                                            UpdatePopupThrownAlready = true;
+                                        }
+
+
+                                        // If it exists in UpgradeFiles (but is an outdated Upgrade...)
+                                        if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
+                                        {
+                                            // Delte from $UpgradeFiles
+                                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
+                                        }
+
+                                        // Move to $UpgradeFiles
+                                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
+                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
+                                    }
+                                    else
+                                    {
+                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path, since file matchings not $UpgradeFiles, not $DowngradeFiles and GTA from $GTA_DIR is NOT upgraded, so we dont want to move files to $UpgradeFiles", 1));
+                                    }
                                 }
                             }
                         }
+
+                        // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
+                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
+                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + FilesInDowngradeFiles[i] + "'", 1));
+                    
+                        HelperClasses.ProcessHandler.KillRockstarProcesses();
+                        RtrnMyFileOperations = MyFileOperationsTmp;
                     }
-
-                    // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
-                    Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
-                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + FilesInDowngradeFiles[i] + "'", 1));
                 }
-
-                HelperClasses.ProcessHandler.KillRockstarProcesses();
-
-                RtrnMyFileOperations = MyFileOperationsTmp;
             }
 
             // Generating the list of MyFileOperations we need to do for a Upgrade
@@ -521,7 +557,7 @@ namespace Project_127.Popups
                     string tmpFileWePlace = FilesInDowngradeAndUpgradePathInDowngradedPathFormat[i].Substring(LauncherLogic.DowngradeFilePath.Length).TrimStart('\\');
 
 
-                    if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic)
+                    if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic && Settings.Retailer != Settings.Retailers.XboxPC)
                     {
                         // Move to $UpgradeFiles
                         MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting '" + CorrespondingFilePathInGTALocation[i] + "' from $GTAInstallationDirectory, since this is a simple Downgrade after using a Backup", 1));
@@ -553,7 +589,7 @@ namespace Project_127.Popups
                                 if (BuildVersionTable.GetGameVersionOfBuild(Globals.GTABuild) > new Version(1, 30))
                                 {
                                     // offer backup
-                                    if (!UpdatePopupThrownAlready)
+                                    if (Settings.Retailer != Settings.Retailers.XboxPC && !UpdatePopupThrownAlready)
                                     {
                                         Application.Current.Dispatcher.Invoke((Action)delegate
                                         {
@@ -600,8 +636,16 @@ namespace Project_127.Popups
                     Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
                     if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]) || ListOfFilePathsAboutToBeInUpgradeFiles.Contains(CorrespondingFilePathInUpgradeFiles[i]))
                     {
-                        // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
-                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, CorrespondingFilePathInUpgradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + CorrespondingFilePathInUpgradeFiles[i] + "'", 1));
+                        if (Settings.Retailer == Settings.Retailers.XboxPC)
+                        {
+                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInUpgradeFiles[i], CorrespondingFilePathInGTALocation[i], "Moving '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $UpgradeFiles to GTA V Installation Path", 1));
+                        }
+
+                        else
+                        {
+                            // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
+                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, CorrespondingFilePathInUpgradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + CorrespondingFilePathInUpgradeFiles[i] + "'", 1));
+                        }
                     }
 
                 }

--- a/Popups/PopupProgress.xaml.cs
+++ b/Popups/PopupProgress.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -381,124 +381,86 @@ namespace Project_127.Popups
                     CorrespondingFilePathInUpgradeFiles[i] = LauncherLogic.UpgradeFilePath + FilesInDowngradeFiles[i].Substring(LauncherLogic.DowngradeFilePath.Length);
 
                     string tmpFileWePlace = FilesInDowngradeFiles[i].Substring(LauncherLogic.DowngradeFilePath.Length).TrimStart('\\');
-                
-                    if (Settings.Retailer == Settings.Retailers.XboxPC)
+
+                    if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic && Settings.Retailer != Settings.Retailers.XboxPC)
                     {
-                        if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInGTALocation[i]))
-                        {
-                            if (!HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
-                            {
-                                if (!HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
-                                {
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
-                                }
-
-                                else if (!HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
-                                {
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
-                                }
-
-                            }
-                        }
-
-                        else
-                        {
-                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Copy, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Copying '" + FilesInDowngradeFiles[i] + "' from $Downgrade_Files to the game folder.", 1));
-                        }
-
-                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
-
-                        HelperClasses.ProcessHandler.KillRockstarProcesses();
-
-                        RtrnMyFileOperations = MyFileOperationsTmp;
+                        // Move to $UpgradeFiles
+                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting '" + CorrespondingFilePathInGTALocation + "' from $GTAInstallationDirectory, since this is a simple Downgrade after using a Backup", 1));
                     }
-
+                    // Normal Downgrade Logic
                     else
                     {
-                    
-                        if (LauncherLogic.IgnoreNewFilesWhileUpgradeDowngradeLogic)
+                        // If the File exists in GTA V Installation Path
+                        if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInGTALocation[i]))
                         {
-                            // Move to $UpgradeFiles
-                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting '" + CorrespondingFilePathInGTALocation + "' from $GTAInstallationDirectory, since this is a simple Downgrade after using a Backup", 1));
-                        }
-                        // Normal Downgrade Logic
-                        else
-                        {
-                            // If the File exists in GTA V Installation Path
-                            if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInGTALocation[i]))
+                            // If the File we are replacing is the same as in DowngradeFiles
+                            if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
                             {
-                                // If the File we are replacing is the same as in DowngradeFiles
-                                if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], FilesInDowngradeFiles[i], MySettings.Settings.EnableSlowCompare))
-                                {
-                                    // Delete from GTA V Installation Path 
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Downgrade_Files. Will delelte from GTA V Installation", 1));
-                                }
+                                // Delete from GTA V Installation Path 
+                                MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Downgrade_Files. Will delelte from GTA V Installation", 1));
+                            }
 
-                                // If the File we are replacing is the same as in UpgradeFiles
-                                else if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
-                                {
-                                    // Delete from GTA V Installation Path
-                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Upgrade_Files. Will delelte from GTA V Installation", 1));
-                                }
+                            // If the File we are replacing is the same as in UpgradeFiles
+                            else if (HelperClasses.FileHandling.AreFilesEqual(CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], MySettings.Settings.EnableSlowCompare))
+                            {
+                                // Delete from GTA V Installation Path
+                                MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Found '" + CorrespondingFilePathInGTALocation[i] + "' in GTA V Installation Path and its the same file as from $Upgrade_Files. Will delelte from GTA V Installation", 1));
+                            }
 
-                                // If the file we are replacing matches no file from UpgradeFiles or DowngradeFiles
+                            // If the file we are replacing matches no file from UpgradeFiles or DowngradeFiles
+                            else
+                            {
+                                // if gta5 is upgraded
+                                if (BuildVersionTable.GetGameVersionOfBuild(Globals.GTABuild) > new Version(1, 30))
+                                {
+                                    // offer backup
+                                    if (!UpdatePopupThrownAlready && Settings.Retailer != Settings.Retailers.XboxPC)
+                                    {
+                                        Application.Current.Dispatcher.Invoke((Action)delegate
+                                        {
+                                            bool yesno = PopupWrapper.PopupYesNo("Detected new Files inside your GTA Installation.\nP127 will use these as the files you revert to when Upgrading.\nDo you want me to back up your previous Upgrade - Files?");
+                                            if (yesno == true)
+                                            {
+                                                HelperClasses.Logger.Log("User does want it. Initiating CreateBackup()");
+
+                                                HelperClasses.ProcessHandler.KillRockstarProcesses();
+
+                                                LauncherLogic.CreateBackup();
+                                            }
+                                            else
+                                            {
+                                                HelperClasses.Logger.Log("User doesnt want it. Alright then");
+                                            }
+                                        });
+                                        UpdatePopupThrownAlready = true;
+                                    }
+
+
+                                    // If it exists in UpgradeFiles (but is an outdated Upgrade...)
+                                    if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
+                                    {
+                                        // Delte from $UpgradeFiles
+                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
+                                    }
+
+                                    // Move to $UpgradeFiles
+                                    Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
+                                }
                                 else
                                 {
-                                    // if gta5 is upgraded
-                                    if (BuildVersionTable.GetGameVersionOfBuild(Globals.GTABuild) > new Version(1, 30))
-                                    {
-                                        // offer backup
-                                        if (!UpdatePopupThrownAlready)
-                                        {
-                                            Application.Current.Dispatcher.Invoke((Action)delegate
-                                            {
-                                                bool yesno = PopupWrapper.PopupYesNo("Detected new Files inside your GTA Installation.\nP127 will use these as the files you revert to when Upgrading.\nDo you want me to back up your previous Upgrade - Files?");
-                                                if (yesno == true)
-                                                {
-                                                    HelperClasses.Logger.Log("User does want it. Initiating CreateBackup()");
-
-                                                    HelperClasses.ProcessHandler.KillRockstarProcesses();
-
-                                                    LauncherLogic.CreateBackup();
-                                                }
-                                                else
-                                                {
-                                                    HelperClasses.Logger.Log("User doesnt want it. Alright then");
-                                                }
-                                            });
-                                            UpdatePopupThrownAlready = true;
-                                        }
-
-
-                                        // If it exists in UpgradeFiles (but is an outdated Upgrade...)
-                                        if (HelperClasses.FileHandling.doesFileExist(CorrespondingFilePathInUpgradeFiles[i]))
-                                        {
-                                            // Delte from $UpgradeFiles
-                                            MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInUpgradeFiles[i], "", "We are overwriting a file which is not equal to the existing files in $Downgrade_Files and $Upgrade_Files. Deleting '" + CorrespondingFilePathInUpgradeFiles[i] + "' from $Upgrade_Files to use the existing File as new Backup", 1));
-                                        }
-
-                                        // Move to $UpgradeFiles
-                                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
-                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Move, CorrespondingFilePathInGTALocation[i], CorrespondingFilePathInUpgradeFiles[i], "Backing up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path to $UpgradeFiles via Moving, since it either doenst exist there yet, or the file from $GTA_Installation_Path is a new one", 1));
-                                    }
-                                    else
-                                    {
-                                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path, since file matchings not $UpgradeFiles, not $DowngradeFiles and GTA from $GTA_DIR is NOT upgraded, so we dont want to move files to $UpgradeFiles", 1));
-                                    }
+                                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Delete, CorrespondingFilePathInGTALocation[i], "", "Deleting up '" + CorrespondingFilePathInGTALocation[i] + "' from GTA V Installation Path, since file matchings not $UpgradeFiles, not $DowngradeFiles and GTA from $GTA_DIR is NOT upgraded, so we dont want to move files to $UpgradeFiles", 1));
                                 }
                             }
                         }
-
-                        // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
-                        Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
-                        MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + FilesInDowngradeFiles[i] + "'", 1));
-                    
-                        HelperClasses.ProcessHandler.KillRockstarProcesses();
-                        RtrnMyFileOperations = MyFileOperationsTmp;
                     }
+
+                    // Creates actual Hard Link (this will further down check if we should copy based on settings in MyFileOperation.Execute())
+                    Settings.AllFilesEverPlacedInsideGTAMyAdd(tmpFileWePlace);
+                    MyFileOperationsTmp.Add(new MyFileOperation(MyFileOperation.FileOperations.Hardlink, FilesInDowngradeFiles[i], CorrespondingFilePathInGTALocation[i], "Will create HardLink in '" + CorrespondingFilePathInGTALocation[i] + "' to the file in '" + FilesInDowngradeFiles[i] + "'", 1));
+
+                    HelperClasses.ProcessHandler.KillRockstarProcesses();
+                    RtrnMyFileOperations = MyFileOperationsTmp;
                 }
             }
 


### PR DESCRIPTION
On XboxPC, the game executables are encrypted and can't be copied. However, they can be deleted or moved, so we avoid hardlinking upgrade files, and move them instead.