### PR TITLE
GetTitleAccessToken is dead, long live GetTitleAccessToken2!

### DIFF
--- a/Auth/ROSCommunicationBackend.cs
+++ b/Auth/ROSCommunicationBackend.cs
@@ -444,12 +444,13 @@ namespace Project_127.Auth
 			byte[] reqBody = EncryptROSData(BuildPostString(
 						new Dictionary<string, string>{
 							{ "ticket", session.ticket },
+							{ "platformId", "8" }, // pcros aka Legacy
 							{ "titleId", "11" },
 						}), session.sessionKey);
 
 			var req = new HttpRequestMessage
 			{
-				RequestUri = new Uri("http://prod.ros.rockstargames.com/launcher/11/launcherservices/app.asmx/GetTitleAccessToken"),
+				RequestUri = new Uri("http://prod.ros.rockstargames.com/launcher/11/launcherservices/app.asmx/GetTitleAccessToken2"),
 				Method = HttpMethod.Post,
 			};
 			req.Headers.Add("Host", "prod.ros.rockstargames.com");


### PR DESCRIPTION
As of 03/08/2026 https://prod.ros.rockstargames.com/launcher/11/launcherservices/app.asmx/GetTitleAccessToken returns DoesNotExist. Migrate to using GetTitleAccessToken2, which takes a platform parameter (8 for pcros aka GTA V Legacy)